### PR TITLE
Support custom pricing for one‑time entries

### DIFF
--- a/src/main/java/com/gym/gymmanagementsystem/dto/UserOneTimeEntryDto.java
+++ b/src/main/java/com/gym/gymmanagementsystem/dto/UserOneTimeEntryDto.java
@@ -3,6 +3,8 @@ package com.gym.gymmanagementsystem.dto;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
+import java.math.BigDecimal;
+
 import java.time.LocalDate;
 
 @Data
@@ -19,6 +21,8 @@ public class UserOneTimeEntryDto {
     private LocalDate purchaseDate;
 
     private Boolean isUsed = false;
+
+    private BigDecimal customPrice;
 
     // Můžeš přidat další pole nebo vztahy podle potřeby
 }

--- a/src/main/java/com/gym/gymmanagementsystem/services/UserOneTimeEntryService.java
+++ b/src/main/java/com/gym/gymmanagementsystem/services/UserOneTimeEntryService.java
@@ -3,13 +3,15 @@ package com.gym.gymmanagementsystem.services;
 
 import com.gym.gymmanagementsystem.entities.UserOneTimeEntry;
 
+import java.math.BigDecimal;
+
 import java.util.List;
 import java.util.Optional;
 
 public interface UserOneTimeEntryService {
     List<UserOneTimeEntry> getAllUserOneTimeEntries();
     Optional<UserOneTimeEntry> getUserOneTimeEntryById(Integer id);
-    UserOneTimeEntry createUserOneTimeEntry(UserOneTimeEntry userOneTimeEntry);
+    UserOneTimeEntry createUserOneTimeEntry(UserOneTimeEntry userOneTimeEntry, BigDecimal customPrice);
     UserOneTimeEntry updateUserOneTimeEntry(Integer id, UserOneTimeEntry userOneTimeEntryDetails);
     void deleteUserOneTimeEntry(Integer id);
     List<UserOneTimeEntry> findByUserId(Integer userId);

--- a/src/main/java/com/gym/gymmanagementsystem/services/UserOneTimeEntryServiceImpl.java
+++ b/src/main/java/com/gym/gymmanagementsystem/services/UserOneTimeEntryServiceImpl.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 
@@ -40,14 +41,14 @@ public class UserOneTimeEntryServiceImpl implements UserOneTimeEntryService {
     }
 
     @Override
-    public UserOneTimeEntry createUserOneTimeEntry(UserOneTimeEntry userOneTimeEntry) {
-        log.info("Vytvářím jednorázový vstup uživatele: {}", userOneTimeEntry);
+    public UserOneTimeEntry createUserOneTimeEntry(UserOneTimeEntry userOneTimeEntry, BigDecimal customPrice) {
+        log.info("Vytvářím jednorázový vstup uživatele: {} customPrice={}", userOneTimeEntry, customPrice);
         UserOneTimeEntry createdEntry = userOneTimeEntryRepository.save(userOneTimeEntry);
-        
+
         // Vytvoření a uložení záznamu transakce
         TransactionHistory transaction = new TransactionHistory();
         transaction.setUser(createdEntry.getUser()); // Předpokládáme, že UserOneTimeEntry má referenci na User
-        transaction.setAmount(createdEntry.getOneTimeEntry().getPrice()); // Předpokládáme, že OneTimeEntry má cenu
+        transaction.setAmount(customPrice != null ? customPrice : createdEntry.getOneTimeEntry().getPrice());
         transaction.setDescription("Nákup jednorázového vstupu " + createdEntry.getOneTimeEntry().getEntryName());
         transaction.setPurchaseType(createdEntry.getOneTimeEntry().getEntryName());
         transaction.setOneTimeEntry(createdEntry);


### PR DESCRIPTION
## Summary
- add optional `customPrice` field to `UserOneTimeEntryDto`
- validate `customPrice` in `createUserOneTimeEntries`
- pass optional `customPrice` to service layer
- store `customPrice` in transaction history when provided

## Testing
- `./gradlew test` *(fails: Flyway requires PostgreSQL connection)*

------
https://chatgpt.com/codex/tasks/task_e_686aed70159483339128407729d5adca