### PR TITLE
Add user names to entry status messages

### DIFF
--- a/src/main/java/com/gym/gymmanagementsystem/dto/EntryStatusMessage.java
+++ b/src/main/java/com/gym/gymmanagementsystem/dto/EntryStatusMessage.java
@@ -14,6 +14,12 @@ public class EntryStatusMessage {
 
     private String userId;
 
+    /** jméno uživatele */
+    private String firstname;
+
+    /** příjmení uživatele */
+    private String lastname;
+
     private String status;
 
     private Integer remainingEntries;

--- a/src/main/java/com/gym/gymmanagementsystem/services/EntryValidationServiceImpl.java
+++ b/src/main/java/com/gym/gymmanagementsystem/services/EntryValidationServiceImpl.java
@@ -53,6 +53,8 @@ public class EntryValidationServiceImpl implements EntryValidationService {
             entryHistoryService.createEntryHistory(history);
             EntryStatusMessage msg = new EntryStatusMessage();
             msg.setUserId(String.valueOf(userId));
+            msg.setFirstname(user.getFirstname());
+            msg.setLastname(user.getLastname());
             msg.setStatus("OK");
             msg.setExpiryDate(active.getEndDate());
             notifyEntryStatus(msg);
@@ -78,6 +80,8 @@ public class EntryValidationServiceImpl implements EntryValidationService {
                     .count();
             EntryStatusMessage msg = new EntryStatusMessage();
             msg.setUserId(String.valueOf(userId));
+            msg.setFirstname(user.getFirstname());
+            msg.setLastname(user.getLastname());
             msg.setStatus("OK");
             msg.setRemainingEntries((int) remaining);
             notifyEntryStatus(msg);
@@ -86,6 +90,8 @@ public class EntryValidationServiceImpl implements EntryValidationService {
 
         EntryStatusMessage msg = new EntryStatusMessage();
         msg.setUserId(String.valueOf(userId));
+        msg.setFirstname(user.getFirstname());
+        msg.setLastname(user.getLastname());
         msg.setStatus("NO_SUBSCRIPTION");
         notifyEntryStatus(msg);
         return new EntryValidationResult(false, null);


### PR DESCRIPTION
## Summary
- extend `EntryStatusMessage` DTO with `firstname` and `lastname`
- populate these fields when sending entry validation status over WebSocket

## Testing
- `./gradlew test --no-daemon` *(fails: java.net.SocketException)*

------
https://chatgpt.com/codex/tasks/task_e_686d739b5a3483339af2acbf189bc939