### PR TITLE
Add motivational text in entry status messages

### DIFF
--- a/src/main/java/com/gym/gymmanagementsystem/dto/EntryStatusMessage.java
+++ b/src/main/java/com/gym/gymmanagementsystem/dto/EntryStatusMessage.java
@@ -23,4 +23,7 @@ public class EntryStatusMessage {
     private Integer remainingEntries;
 
     private LocalDate expiryDate;
+
+    /** Motivational text shown with the entry result. */
+    private String text;
 }

--- a/src/main/java/com/gym/gymmanagementsystem/dto/MotivationalMessage.java
+++ b/src/main/java/com/gym/gymmanagementsystem/dto/MotivationalMessage.java
@@ -1,0 +1,36 @@
+package com.gym.gymmanagementsystem.dto;
+
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Enum of motivational messages sent to the user when entering the gym.
+ */
+public enum MotivationalMessage {
+    WORKOUT_NICELY("P\u011bkn\u011b si zacvi\u010d!"),
+    TODAY_YOU_CAN("Dnes to zvl\u00e1dne\u0161 na jedni\u010dku!"),
+    EVERY_SQUAT_COUNTS("Ka\u017ed\u00fd d\u0159ep se po\u010d\u00edt\u00e1!"),
+    STRENGTH_GROWS("S\u00edla roste s ka\u017ed\u00fdm vstupem!"),
+    FUTURE_YOU_THANKS("Tv\u016fj budouc\u00ed j\u00e1 ti pod\u011bkuje!");
+
+    private final String text;
+
+    MotivationalMessage(String text) {
+        this.text = text;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    private static final List<MotivationalMessage> VALUES = List.of(values());
+    private static final int SIZE = VALUES.size();
+    private static final Random RANDOM = new Random();
+
+    /**
+     * Returns a random motivational message text.
+     */
+    public static String randomText() {
+        return VALUES.get(RANDOM.nextInt(SIZE)).getText();
+    }
+}

--- a/src/main/java/com/gym/gymmanagementsystem/services/EntryValidationServiceImpl.java
+++ b/src/main/java/com/gym/gymmanagementsystem/services/EntryValidationServiceImpl.java
@@ -6,6 +6,7 @@ import com.gym.gymmanagementsystem.entities.UserOneTimeEntry;
 import com.gym.gymmanagementsystem.entities.UserSubscription;
 import com.gym.gymmanagementsystem.exceptions.ResourceNotFoundException;
 import com.gym.gymmanagementsystem.dto.EntryStatusMessage;
+import com.gym.gymmanagementsystem.dto.MotivationalMessage;
 import com.gym.gymmanagementsystem.repositories.UserOneTimeEntryRepository;
 import com.gym.gymmanagementsystem.repositories.UserRepository;
 import com.gym.gymmanagementsystem.repositories.UserSubscriptionRepository;
@@ -57,6 +58,7 @@ public class EntryValidationServiceImpl implements EntryValidationService {
             msg.setLastname(user.getLastname());
             msg.setStatus("OK_SUBSCRIPTION");
             msg.setExpiryDate(active.getEndDate());
+            msg.setText(MotivationalMessage.randomText());
             notifyEntryStatus(msg);
             return new EntryValidationResult(true, "Subscription");
         }
@@ -84,6 +86,7 @@ public class EntryValidationServiceImpl implements EntryValidationService {
             msg.setUserId(String.valueOf(userId));
             msg.setStatus("OK_ONE_TIME_ENTRY");
             msg.setRemainingEntries((int) remaining);
+            msg.setText(MotivationalMessage.randomText());
             notifyEntryStatus(msg);
             return new EntryValidationResult(true, "OneTimeEntry");
         }
@@ -93,6 +96,7 @@ public class EntryValidationServiceImpl implements EntryValidationService {
         msg.setFirstname(user.getFirstname());
         msg.setLastname(user.getLastname());
         msg.setStatus("NO_VALID_ENTRY");
+        msg.setText(MotivationalMessage.randomText());
         notifyEntryStatus(msg);
         return new EntryValidationResult(false, null);
     }


### PR DESCRIPTION
## Summary
- expand `EntryStatusMessage` DTO with a motivational text field
- add `MotivationalMessage` enum with random message generator
- include a random motivational text when sending entry status updates

## Testing
- `./gradlew test` *(fails: Flyway could not connect to PostgreSQL)*

------
https://chatgpt.com/codex/tasks/task_e_686d97cd864c83338d9b4f4e2379dc66