### PR TITLE
Add support for unregistered one time entry purchase

### DIFF
--- a/src/main/java/com/gym/gymmanagementsystem/controllers/UserOneTimeEntryController.java
+++ b/src/main/java/com/gym/gymmanagementsystem/controllers/UserOneTimeEntryController.java
@@ -126,6 +126,33 @@ public class UserOneTimeEntryController {
     }
 
     /**
+     * Vytvoří jednorázové vstupy pro neregistrovaného uživatele.
+     */
+    @PostMapping("/unregistered")
+    public ResponseEntity<List<UserOneTimeEntryDto>> createForUnregistered(
+            @Valid @RequestBody UserOneTimeEntryDto userOneTimeEntryDto,
+            @RequestParam(value = "count", defaultValue = "1") int count) {
+        log.info("POST /api/user-one-time-entries/unregistered count={} - {}", count, userOneTimeEntryDto);
+
+        if (userOneTimeEntryDto.getCardNumber() == null || userOneTimeEntryDto.getCardNumber().isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "cardNumber je povinné");
+        }
+
+        if (userOneTimeEntryDto.getOneTimeEntryID() != null && userOneTimeEntryDto.getOneTimeEntryID().equals(3)) {
+            if (userOneTimeEntryDto.getCustomPrice() == null) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Pole customPrice je povinné pro oneTimeEntryID = 3");
+            }
+        } else if (userOneTimeEntryDto.getCustomPrice() != null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "customPrice lze zadat pouze pro oneTimeEntryID = 3");
+        }
+
+        List<UserOneTimeEntry> created = userOneTimeEntryService.createEntriesForUnregistered(userOneTimeEntryDto, count);
+        List<UserOneTimeEntryDto> result = created.stream().map(mapper::toDto).toList();
+        log.debug("Vytvořeno {} záznamů", result.size());
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
+    }
+
+    /**
      * Aktualizuje informace o jednorázovém vstupu uživatele podle jeho ID.
      *
      * @param id               ID jednorázového vstupu uživatele, který chceme aktualizovat.

--- a/src/main/java/com/gym/gymmanagementsystem/dto/UserOneTimeEntryDto.java
+++ b/src/main/java/com/gym/gymmanagementsystem/dto/UserOneTimeEntryDto.java
@@ -24,5 +24,8 @@ public class UserOneTimeEntryDto {
 
     private BigDecimal customPrice;
 
+    // číslo karty použité při nákupu pro neregistrované uživatele
+    private String cardNumber;
+
     // Můžeš přidat další pole nebo vztahy podle potřeby
 }

--- a/src/main/java/com/gym/gymmanagementsystem/repositories/UserOneTimeEntryRepository.java
+++ b/src/main/java/com/gym/gymmanagementsystem/repositories/UserOneTimeEntryRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface UserOneTimeEntryRepository extends JpaRepository<UserOneTimeEntry, Integer> {
     List<UserOneTimeEntry> findByUserUserID(Integer userID);
     List<UserOneTimeEntry> findByIsUsedFalse();
+    long countByUserUserIDAndIsUsedFalse(Integer userID);
+    UserOneTimeEntry findFirstByUserUserIDAndIsUsedFalse(Integer userID);
 }

--- a/src/main/java/com/gym/gymmanagementsystem/repositories/UserRepository.java
+++ b/src/main/java/com/gym/gymmanagementsystem/repositories/UserRepository.java
@@ -28,4 +28,9 @@ public interface UserRepository extends JpaRepository<User, Integer>, JpaSpecifi
      */
     List<User> findByFirstnameContainingIgnoreCaseOrLastnameContainingIgnoreCase(String firstname, String lastname);
 
+    /**
+     * Vrátí všechny falešné uživatele (realUser = false).
+     */
+    List<User> findByRealUserFalse();
+
 }

--- a/src/main/java/com/gym/gymmanagementsystem/services/EntryValidationServiceImpl.java
+++ b/src/main/java/com/gym/gymmanagementsystem/services/EntryValidationServiceImpl.java
@@ -34,6 +34,8 @@ public class EntryValidationServiceImpl implements EntryValidationService {
     private EntryHistoryService entryHistoryService;
     @Autowired
     private SimpMessagingTemplate simpMessagingTemplate;
+    @Autowired
+    private UserService userService;
 
     @Override
     public EntryValidationResult canUserEnter(Integer userId) {
@@ -71,6 +73,10 @@ public class EntryValidationServiceImpl implements EntryValidationService {
         if (oneTime != null) {
             oneTime.setIsUsed(true);
             userOneTimeEntryRepository.save(oneTime);
+
+            if (Boolean.FALSE.equals(user.getRealUser())) {
+                userService.unsignCard(user.getUserID());
+            }
 
             EntryHistory history = new EntryHistory();
             history.setUser(user);

--- a/src/main/java/com/gym/gymmanagementsystem/services/UserOneTimeEntryService.java
+++ b/src/main/java/com/gym/gymmanagementsystem/services/UserOneTimeEntryService.java
@@ -2,6 +2,7 @@ package com.gym.gymmanagementsystem.services;
 
 
 import com.gym.gymmanagementsystem.entities.UserOneTimeEntry;
+import com.gym.gymmanagementsystem.dto.UserOneTimeEntryDto;
 
 import java.math.BigDecimal;
 
@@ -16,4 +17,13 @@ public interface UserOneTimeEntryService {
     void deleteUserOneTimeEntry(Integer id);
     List<UserOneTimeEntry> findByUserId(Integer userId);
     List<UserOneTimeEntry> findUnusedEntries();
+
+    /**
+     * Vytvoří jednorázové vstupy pro neregistrovaného uživatele.
+     *
+     * @param dto   informace o vstupu včetně cardNumber
+     * @param count počet vstupů
+     * @return seznam vytvořených vstupů
+     */
+    List<UserOneTimeEntry> createEntriesForUnregistered(UserOneTimeEntryDto dto, int count);
 }

--- a/src/main/java/com/gym/gymmanagementsystem/services/UserService.java
+++ b/src/main/java/com/gym/gymmanagementsystem/services/UserService.java
@@ -56,6 +56,13 @@ public interface UserService {
     void assignCardToUser(Integer userId, String cardNumber);
 
     /**
+     * Odstraní přiřazení karty od uživatele.
+     *
+     * @param userId ID uživatele
+     */
+    void unsignCard(Integer userId);
+
+    /**
      * Vyhledá uživatele podle čísla karty.
      * <p>
      * Pokud karta s daným číslem neexistuje, vyhodí {@link com.gym.gymmanagementsystem.exceptions.ResourceNotFoundException}.

--- a/src/main/java/com/gym/gymmanagementsystem/services/UserServiceImpl.java
+++ b/src/main/java/com/gym/gymmanagementsystem/services/UserServiceImpl.java
@@ -280,6 +280,25 @@ public class UserServiceImpl implements UserService {
         log.info("Karta {} úspěšně přiřazena uživateli {}", cardNumber, userId);
     }
 
+    @Override
+    public void unsignCard(Integer userId) {
+        log.info("Odpájím kartu od uživatele {}", userId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found with id " + userId));
+
+        if (user.getCard() == null) {
+            log.warn("Uživatel {} nemá přiřazenou kartu", userId);
+            return;
+        }
+
+        var card = user.getCard();
+        card.setUser(null);
+        user.setCard(null);
+        cardRepository.save(card);
+        userRepository.save(user);
+        log.info("Karta od uživatele {} úspěšně odebrána", userId);
+    }
+
     /**
      * Najde stav karty a případně uživatele.
      *


### PR DESCRIPTION
## Summary
- allow `UserOneTimeEntryDto` to carry card number
- expose `/user-one-time-entries/unregistered` endpoint
- implement creation of fake users and assigning cards
- detach card from fake users once entry is used
- add helper repository/service methods

## Testing
- `./gradlew test --no-daemon` *(fails: Flyway connection error)*

------
https://chatgpt.com/codex/tasks/task_e_686ede698c28833384b29d5edf016b62