### PR TITLE
Add user points logic

### DIFF
--- a/src/main/java/com/gym/gymmanagementsystem/controllers/UserController.java
+++ b/src/main/java/com/gym/gymmanagementsystem/controllers/UserController.java
@@ -291,6 +291,7 @@ public class UserController {
             dto.setFirstname(u.getFirstname());
             dto.setLastname(u.getLastname());
             dto.setEmail(u.getEmail());
+            dto.setPoints(u.getPoints());
 
             // Pokud má uživatel fotku, sestavíme URL ke stažení
             if (u.getProfilePhoto() != null && !u.getProfilePhoto().isEmpty()) {

--- a/src/main/java/com/gym/gymmanagementsystem/dto/DetailedUserDto.java
+++ b/src/main/java/com/gym/gymmanagementsystem/dto/DetailedUserDto.java
@@ -18,6 +18,8 @@ public class DetailedUserDto {
     private String email;
     private String profilePhotoPath; // URL ke stažení fotky, např. "/api/users/{id}/profilePhoto"
 
+    private Integer points;
+
     private List<UserSubscriptionDto> subscriptions;
 
     private List<EntryHistoryDto> entryHistories;

--- a/src/main/java/com/gym/gymmanagementsystem/dto/UserDto.java
+++ b/src/main/java/com/gym/gymmanagementsystem/dto/UserDto.java
@@ -37,6 +37,8 @@ public class UserDto {
 
     private Boolean realUser = true;
 
+    private Integer points;
+
     // Vztahy mohou být reprezentovány pomocí ID nebo dalších DTO
     private Integer cardID;
     private Integer activeSubscriptionID;

--- a/src/main/java/com/gym/gymmanagementsystem/dto/mappers/UserMapper.java
+++ b/src/main/java/com/gym/gymmanagementsystem/dto/mappers/UserMapper.java
@@ -33,6 +33,9 @@ public class UserMapper {
         user.setBirthdate(userDto.getBirthdate());
         user.setProfilePhoto(userDto.getProfilePhoto());
         user.setRealUser(userDto.getRealUser());
+        if (userDto.getPoints() != null) {
+            user.setPoints(userDto.getPoints());
+        }
 
         if (userDto.getCardID() != null) {
             Card card = cardRepository.findById(userDto.getCardID()).orElse(null);
@@ -63,6 +66,7 @@ public class UserMapper {
         dto.setBirthdate(user.getBirthdate());
         dto.setProfilePhoto(user.getProfilePhoto());
         dto.setRealUser(user.getRealUser());
+        dto.setPoints(user.getPoints());
 
         if (user.getCard() != null) {
             dto.setCardID(user.getCard().getCardID());

--- a/src/main/java/com/gym/gymmanagementsystem/entities/User.java
+++ b/src/main/java/com/gym/gymmanagementsystem/entities/User.java
@@ -34,6 +34,9 @@ public class User {
     @Column(name = "birthdate")
     private LocalDate birthdate;
 
+    @Column(name = "points")
+    private Integer points = 0;
+
     @Column(length = 200)
     private String profilePhoto;
 

--- a/src/main/java/com/gym/gymmanagementsystem/services/EntryValidationServiceImpl.java
+++ b/src/main/java/com/gym/gymmanagementsystem/services/EntryValidationServiceImpl.java
@@ -54,6 +54,8 @@ public class EntryValidationServiceImpl implements EntryValidationService {
             history.setUser(user);
             history.setEntryType("Subscription");
             entryHistoryService.createEntryHistory(history);
+            user.setPoints(user.getPoints() + 1);
+            userRepository.save(user);
             EntryStatusMessage msg = new EntryStatusMessage();
             msg.setUserId(String.valueOf(userId));
             msg.setFirstname(user.getFirstname());
@@ -73,6 +75,9 @@ public class EntryValidationServiceImpl implements EntryValidationService {
         if (oneTime != null) {
             oneTime.setIsUsed(true);
             userOneTimeEntryRepository.save(oneTime);
+
+            user.setPoints(user.getPoints() + 1);
+            userRepository.save(user);
 
             if (Boolean.FALSE.equals(user.getRealUser())) {
                 userService.unsignCard(user.getUserID());

--- a/src/main/resources/db/migration/V2__add_points_column.sql
+++ b/src/main/resources/db/migration/V2__add_points_column.sql
@@ -1,0 +1,3 @@
+ALTER TABLE Users
+    ADD COLUMN Points INT DEFAULT 0;
+


### PR DESCRIPTION
## Summary
- add `points` column to `User` entity and migration
- update DTOs and mapper to include points information
- return points in detailed user list
- increment points on successful entry validation

## Testing
- `bash gradlew test --no-daemon` *(fails: FlywaySqlException due to PostgreSQL connection)*

------
https://chatgpt.com/codex/tasks/task_e_686fa31e9940833384971cfaf211ccaf