### PR TITLE
Fix profile photo orientation on upload

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,9 @@ dependencies {
         // Knihovna pro kompresi obrazků
         implementation 'net.coobird:thumbnailator:0.4.20'
 
+        // Knihovna pro čtení EXIF metadat (orientace obrázku)
+        implementation 'com.drewnoakes:metadata-extractor:2.18.0'
+
 
 	implementation 'org.mapstruct:mapstruct:1.5.5.Final'
 	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'


### PR DESCRIPTION
## Summary
- add metadata-extractor dependency
- rotate uploaded profile photos using EXIF orientation

## Testing
- `./gradlew test` *(fails: PSQLException when connecting to database)*

------
https://chatgpt.com/codex/tasks/task_e_68702b32cd40833392084e84e17e67c7