### PR TITLE
Add selectable profile photo quality

### DIFF
--- a/src/main/java/com/gym/gymmanagementsystem/controllers/UserController.java
+++ b/src/main/java/com/gym/gymmanagementsystem/controllers/UserController.java
@@ -13,6 +13,7 @@ import com.gym.gymmanagementsystem.entities.UserSubscription;
 import com.gym.gymmanagementsystem.exceptions.ResourceNotFoundException;
 import com.gym.gymmanagementsystem.services.EntryHistoryService;
 import com.gym.gymmanagementsystem.services.UserService;
+import com.gym.gymmanagementsystem.dto.enums.PhotoQuality;
 import com.gym.gymmanagementsystem.services.UserSubscriptionService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -222,9 +223,10 @@ public class UserController {
     }
 
     @GetMapping("/{id}/profilePhoto")
-    public ResponseEntity<Resource> getProfilePhoto(@PathVariable Integer id) {
-        log.info("GET /api/users/{}/profilePhoto", id);
-        FileResourceData fileData = userService.loadProfilePicture(id);
+    public ResponseEntity<Resource> getProfilePhoto(@PathVariable Integer id,
+                                                    @RequestParam(value = "quality", defaultValue = "HIGH") PhotoQuality quality) {
+        log.info("GET /api/users/{}/profilePhoto quality={}", id, quality);
+        FileResourceData fileData = userService.loadProfilePicture(id, quality);
 
         log.debug("Profilová fotka {} načtena", fileData.getResource().getFilename());
 
@@ -293,9 +295,9 @@ public class UserController {
             dto.setEmail(u.getEmail());
             dto.setPoints(u.getPoints());
 
-            // Pokud má uživatel fotku, sestavíme URL ke stažení nejkvalitnější varianty
+            // Pokud má uživatel fotku, sestavíme základní URL pro stažení
             if (u.getProfilePhoto() != null && !u.getProfilePhoto().isEmpty()) {
-                dto.setProfilePhotoPath("/avatars/high_" + u.getProfilePhoto());
+                dto.setProfilePhotoPath("/api/users/" + u.getUserID() + "/profilePhoto");
             }
 
             // Příklad: pokud máš v entitě collection subscription, mapuj je pomocí odpovídajícího mapperu

--- a/src/main/java/com/gym/gymmanagementsystem/dto/DetailedUserDto.java
+++ b/src/main/java/com/gym/gymmanagementsystem/dto/DetailedUserDto.java
@@ -16,7 +16,7 @@ public class DetailedUserDto {
     private String firstname;
     private String lastname;
     private String email;
-    // URL ke stažení nejkvalitnější verze profilové fotky (např. "/avatars/high_<filename>")
+    // Základní URL pro stažení profilové fotky. Kvalitu lze určit pomocí parametru "quality".
     private String profilePhotoPath;
 
     private Integer points;

--- a/src/main/java/com/gym/gymmanagementsystem/dto/enums/PhotoQuality.java
+++ b/src/main/java/com/gym/gymmanagementsystem/dto/enums/PhotoQuality.java
@@ -1,0 +1,17 @@
+package com.gym.gymmanagementsystem.dto.enums;
+
+/**
+ * Representuje dostupné kvality profilových fotografií.
+ */
+public enum PhotoQuality {
+    LOW,
+    MEDIUM,
+    HIGH;
+
+    /**
+     * Vrací prefix souboru pro danou kvalitu (např. "low_", "medium_", "high_").
+     */
+    public String prefix() {
+        return this.name().toLowerCase() + "_";
+    }
+}

--- a/src/main/java/com/gym/gymmanagementsystem/services/UserService.java
+++ b/src/main/java/com/gym/gymmanagementsystem/services/UserService.java
@@ -7,6 +7,7 @@ import com.gym.gymmanagementsystem.entities.User;
 import org.apache.catalina.webresources.FileResource;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.core.io.Resource;
+import com.gym.gymmanagementsystem.dto.enums.PhotoQuality;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -23,12 +24,13 @@ public interface UserService {
 
     List<User> searchUsers(String searchTerm);
     /**
-     * Načte profilovou fotku daného uživatele jako Resource.
+     * Načte profilovou fotku daného uživatele jako {@link org.springframework.core.io.Resource}.
      *
-     * @param userId ID uživatele
+     * @param userId  ID uživatele
+     * @param quality požadovaná kvalita fotografie (LOW, MEDIUM, HIGH)
      * @return FileResourceData (s Resource a contentType), nebo vyhodí výjimku, pokud fotka neexistuje
      */
-    FileResourceData loadProfilePicture(Integer userId);
+    FileResourceData loadProfilePicture(Integer userId, PhotoQuality quality);
 
 
     /**

--- a/src/main/java/com/gym/gymmanagementsystem/services/UserServiceImpl.java
+++ b/src/main/java/com/gym/gymmanagementsystem/services/UserServiceImpl.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
+import com.gym.gymmanagementsystem.dto.enums.PhotoQuality;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -243,7 +244,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public FileResourceData loadProfilePicture(Integer userId) {
+    public FileResourceData loadProfilePicture(Integer userId, PhotoQuality quality) {
         // 1) Najdeme uživatele
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found with id " + userId));
@@ -254,8 +255,9 @@ public class UserServiceImpl implements UserService {
             throw new ResourceNotFoundException("User " + userId + " has no profile photo set.");
         }
 
-        // 3) Složíme fyzickou cestu k souboru (použijeme nejkvalitnější variantu)
-        Path filePath = Paths.get(uploadDir).resolve("high_" + photoFilename).normalize();
+        // 3) Složíme fyzickou cestu k souboru dle zvolené kvality
+        String prefix = (quality != null ? quality.prefix() : PhotoQuality.HIGH.prefix());
+        Path filePath = Paths.get(uploadDir).resolve(prefix + photoFilename).normalize();
         if (!Files.exists(filePath)) {
             throw new ResourceNotFoundException("Photo file not found: " + filePath);
         }


### PR DESCRIPTION
## Summary
- add enum `PhotoQuality` for high/medium/low variants
- allow specifying quality when retrieving profile photos
- adjust detailed user listing to provide base URL for photos

## Testing
- `./gradlew test` *(fails: FlywaySqlException - PSQLException SocketException)*

------
https://chatgpt.com/codex/tasks/task_e_6870e10e0e148333827cbec74c71a5ff